### PR TITLE
Fix for different kind of formats in the DTSTART and DTEND fields.

### DIFF
--- a/ics2baikal.pl
+++ b/ics2baikal.pl
@@ -48,8 +48,10 @@ while($content =~ /(BEGIN:VEVENT.+?END:VEVENT)/gis) { # match an event
 	my $event = "BEGIN:VCALENDAR\n$1\nEND:VCALENDAR";
 	my ($uid) = ($event =~ m/^UID:(.+)$/im);
 	my ($lastmodified) 	= ($event =~ m/^LAST-MODIFIED:(.+)$/im);
-	my ($eventstart) 	= ($event =~ m/^DTSTART:(.+)$/im);
-	my ($eventend) 		= ($event =~ m/^DTEND:(.+)$/im);
+	my $res 	= ($event =~ m/^DTSTART(:|;TZID=|;VALUE=DATE:)(.+)$/im);
+	my ($eventstart) 	= $2;
+	my $res 	= ($event =~ m/^DTEND(:|;TZID=|;VALUE=DATE:)(.+)$/im);
+	my ($eventend) 	= $2;
 	print "EVENT detected : $uid\n" unless $quiet;
 
 	my $sql  = 	$sql_col.


### PR DESCRIPTION
Hi

Thank you for having written this script.

When running it on my events, I have observed that the the `DTSTART` and `DTEND` fields can have 3 different formats, and thus updated the regex (note that I am not really knowledgeable in perl, so my solution is probably not optimal):
- the format recognized by the regex: `DTSTART:20240206T100000`;
- format with a timezone: `DTSTART;TZID=Asia/Tokyo:20240208T093000`;
- format with just a date: `DTSTART;VALUE=DATE:20221105`.